### PR TITLE
Control dialer's incoming call proximity sensor check via an overlay

### DIFF
--- a/java/com/android/incallui/answerproximitysensor/AnswerProximitySensor.java
+++ b/java/com/android/incallui/answerproximitysensor/AnswerProximitySensor.java
@@ -26,6 +26,8 @@ import com.android.incallui.call.DialerCall;
 import com.android.incallui.call.DialerCall.State;
 import com.android.incallui.call.DialerCallListener;
 
+import com.android.incallui.R;
+
 /**
  * This class prevents users from accidentally answering calls by keeping the screen off until the
  * proximity sensor is unblocked. If the screen is already on or if this is a call waiting call then
@@ -53,6 +55,11 @@ public class AnswerProximitySensor
     if (!ConfigProviderBindings.get(context)
         .getBoolean(CONFIG_ANSWER_PROXIMITY_SENSOR_ENABLED, true)) {
       LogUtil.i("AnswerProximitySensor.shouldUse", "disabled by config");
+      return false;
+    }
+
+    if (!context.getResources().getBoolean(R.bool.config_answer_proximity_sensor_enabled)) {
+      LogUtil.i("AnswerProximitySensor.shouldUse", "disabled by overlay");
       return false;
     }
 

--- a/java/com/android/incallui/res/values/lineage_config.xml
+++ b/java/com/android/incallui/res/values/lineage_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2018 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+  <!-- Whether to check that the proximity is unblocked before showing the incoming call UI. -->
+  <bool name="config_answer_proximity_sensor_enabled">true</bool>
+</resources>


### PR DESCRIPTION
This feature can't be used on devices with proximity sensors that don't
work when the screen is off, e.g. sensors using ultrasound technology.
The result in those cases is a black screen with just the status bar
showing, instead of the normal incoming call UI.

Make it possible to opt-out via an overlay.

Change-Id: Ic3848d09e1ed80e5409cbecbaca2517db16ed0b8