### PR TITLE
Dialer: Properly depend on Lineage SDK

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -309,7 +309,7 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
 	libphonenumber \
 	okhttp \
 	volley \
-	org.lineageos.platform.sdk
+	org.lineageos.platform.internal
 
 LOCAL_STATIC_ANDROID_LIBRARIES := \
 	android-support-design \


### PR DESCRIPTION
 * Platform apps that depend on the SDK must only link
   against org.lineageos.platform.internal

Change-Id: Ibf63433f0961572d118361f984270f56accf8409