### PR TITLE
Allow call recording for Austria

### DIFF
--- a/java/com/android/dialer/callrecord/res/values-mcc232/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc232/config.xml
@@ -14,6 +14,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Austria-->
+<!--Legal precedent source: § 93 TKG 2003 Kommunikationsgeheimnis, https://www.ris.bka.gv.at/GeltendeFassung.wxe?Abfrage=Bundesnormen&Gesetzesnummer=20002849 -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>


### PR DESCRIPTION
 * Call recording is legal in Austria, so it should be available in the UI

Change-Id: Iaae0b222d2a1108572832732471e7e063f84dd1f