### PR TITLE
Enable Call Recording for Sri Lanka and Costa Rica.

### DIFF
--- a/java/com/android/dialer/callrecord/res/values-mcc250/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc250/config.xml
@@ -35,7 +35,6 @@
      https://www.consultant.ru/document/cons_doc_LAW_61798/35f4fb38534799919febebd589466c9838f571b2/
      Civil Procedure Code of 2002, N 138-FZ:
      https://www.consultant.ru/document/cons_doc_LAW_39570/b48406042a309ee368f395fb6f3be1d43c7cbfc2/
-     
 -->
 <resources>
 

--- a/java/com/android/dialer/callrecord/res/values-mcc413/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc413/config.xml
@@ -16,16 +16,18 @@
      limitations under the License.
 -->
 
-<!--Enable call recording for country: Belgium-->
+<!--Enable call recording for country: Sri Lanka-->
 <!--
      Relevant laws and/or legal precedents:
-     As stated in the official response below, Belgian law does not consider the recording of one's
-     personal communications as a punishable offense. Using said recordings in a fraudulent and/or
-     demeaning way does carry the potential for liability and/or prosecution by the state. The
-     recording of one's own calls might be regarded as a form of personal data processing, depending
-     on the specifics of the case. Specific laws and cases are quoted within the official response.
-     Official Response by Belgian Minister (QRVA 50 157, internal pages 20199-20202, 24/02/2003):
-     https://www.lachambre.be/QRVA/pdf/50/50K0157.pdf
+     Part IV/59 of the Sri Lankan Telecommunications Act defines the penalty for eavesdropping on a
+     call. The Sri Lankan Penal Code does not cover the act of recording one's own calls, hence the
+     act is not criminally punishable.
+     Telecommunications Act:
+     https://www.lawnet.gov.lk/1947/12/31/sri-lanka-telecommunications-2/
+     Penal Code:
+     https://www.lawnet.gov.lk/penal-code-consolidated-2/
+     Article: (nonsecure link)
+     http://www.dailymirror.lk/article/PTL-tampered-with-phone-recording-system-ASG-135574.html
 -->
 <resources>
 

--- a/java/com/android/dialer/callrecord/res/values-mcc712/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc712/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2014-2016 The CyanogenMod Project
+     Copyright (C) 2016-2019 The LineageOS Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<!--Enable call recording for country: Costa Rica-->
+<!--
+     Relevant laws and/or legal precedents:
+     One may record one's own calls, as long as they are calls between said person and only one
+     other party, that is two say two sides. Calls between 3 or more people can not be legally
+     recorded without all sides agreeing to one person doing so, as long as said person is a part of
+     the call and not wiretapping or eavesdropping. Recording calls with more than 2 participants
+     requires the express consent of all other parties. Article 29 of the Communication Law of 1994
+     specifies under what circumstances one may or may not do so.
+     Communication Law:
+     http://www.pgrweb.go.cr/scij/Busqueda/Normativa/Normas/nrm_texto_completo.aspx?param1=NRM&nValor1=1&nValor2=16466&strTipM=FN
+     Article:
+     https://www.laprensalibre.cr/Noticias/detalle/75929/ojo-conversaciones-grabadas-pueden-usarse-como-prueba-en-juicio
+-->
+<resources>
+
+</resources>


### PR DESCRIPTION
* Call recording is enabled for: Sri Lanka (413) and Costa Rica (712).
* Fixes: Removed newline from Belgium (206) and space from Russia (250).

Change-Id: I4c9ecf41e9fd472b97fff5cd03800414737be87a